### PR TITLE
Add note to use Python 3.8 because of PyTorch 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 6) [Citation](#citation)
 
 ## Requirements
+
+The code requires Python 3.8 because PyTorch 1.7 [doesn't support Python versions above 3.8](https://github.com/pytorch/pytorch/issues/47354).
+
+After verifying that you are using Python 3.8, install the dependencies with:
+
 ```bash
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
PyTorch 1.7 requires Python 3.8. Refer to the discussion in https://github.com/pytorch/pytorch/issues/47354.

Suggest adding this note to the README to help reproduce the environment because running `pip install -r requirements.txt` with the wrong version of Python gives an obscure error message. 